### PR TITLE
fix(simple.html): tweak font-color

### DIFF
--- a/layouts/partials/widgets/simple.html
+++ b/layouts/partials/widgets/simple.html
@@ -1,9 +1,9 @@
 <!-- <div style="{{ printf "height: %s;" .page.Params.height | safeCSS }}"> -->
 
 
-<div align=center style="font-size: 2rem; color: black"> {{ .page.Params.title }} </div>
+<div align=center style="font-size: 2rem;"> {{ .page.Params.title }} </div>
 
-<div style="font-size: 1rem; color: black">
+<div style="font-size: 1rem;">
   {{ .page.Content }}
 </div>
 


### PR DESCRIPTION
Hi, I tweaked some code to enhance the font-color attributes.
Currently the texts in some sections are displayed with black font color when dark mode is enabled, which makes it not eazy to read in such case.

Before:
<details>
  <summary>Light mode</summary>
  
![image](https://github.com/cgenglab/cgenglab.github.io/assets/10584186/251cc0e9-9564-4c9c-8be4-c5381ffaa025)

</details>

<details>
  <summary>Dark mode</summary>

![image](https://github.com/cgenglab/cgenglab.github.io/assets/10584186/d3c80435-4634-4190-a679-eec0bf66a8fb)

</details>

After:
<details>
  <summary>Light mode</summary>

![image](https://github.com/cgenglab/cgenglab.github.io/assets/10584186/76c6f956-0d44-4ac3-b2e7-df5bc651b365)

</details>

<details>
  <summary>Dark mode</summary>

![image](https://github.com/cgenglab/cgenglab.github.io/assets/10584186/322ca093-60f8-4643-aaa1-cad295ce77dd)

</details>